### PR TITLE
Enhancement: Use `actions/labeler@v5` and migrate format used in `labeler.yml`

### DIFF
--- a/.github/workflows/triage.yaml
+++ b/.github/workflows/triage.yaml
@@ -21,6 +21,10 @@ jobs:
 
         steps:
             -
+                name: "Checkout"
+                uses: "actions/checkout@v4"
+
+            -
                 name: "Add labels based on modified files"
                 uses: "actions/labeler@v5"
                 with:


### PR DESCRIPTION
_Created by [PR-Factory](https://github.com/datana-gmbh/pr-factory)_ using the following command:

```bash

symfony console \
   project:github-actions:labeler-5 \
   --delete-branch-if-exists \
   -vv \
   scanio-lite

```
